### PR TITLE
feat: add linux support

### DIFF
--- a/Formula/setops-cli.rb
+++ b/Formula/setops-cli.rb
@@ -1,16 +1,30 @@
 class SetopsCli < Formula
   desc "The only tool you need to run your cloud applications"
   homepage "https://setops.co"
-  url "https://api.github.com/repos/setopsco/releases/releases/assets/35904653",
-      header: "Accept: application/octet-stream"
+
+  on_macos do
+    url "https://api.github.com/repos/setopsco/releases/releases/assets/35904653",
+        header: "Accept: application/octet-stream"
+    sha256 "50c22084b587a47f611be012f1b7e861ac6002bda0cbc525c109aca3586cc5c9"
+  end
+
+  on_linux do
+    url "https://api.github.com/repos/setopsco/releases/releases/assets/35904649",
+        header: "Accept: application/octet-stream"
+    sha256 "de0498665ed9ba3420f7a26c48f501a8ee69fbe25d281863386af73648bc76d4"
+  end
+
   version "0.2.2"
-  sha256 "50c22084b587a47f611be012f1b7e861ac6002bda0cbc525c109aca3586cc5c9"
   # TODO: Update license (see https://docs.brew.sh/Formula-Cookbook)
   license :cannot_represent
 
   bottle :unneeded
 
-  RELEASE_FILE_NAME = "setops-cli_v0.2.2_darwin_amd64".freeze
+  RELEASE_FILE_NAME = if OS.mac?
+    "setops-cli_v0.2.2_darwin_amd64"
+  else
+    "setops-cli_v0.2.2_linux_amd64"
+  end.freeze
 
   def install
     bin.install RELEASE_FILE_NAME => "setops"


### PR DESCRIPTION
I added conditional code to the formula using brew's [`OS`](https://rubydoc.brew.sh/OS.html) classes and implemented OS-specific asset paths.

- differentiate between mac and linux environment
- download and install OS-specific version

This allowed me to install setops using brew under Windows-Subsystem-for-Linux without any problems.